### PR TITLE
Bump bitcore-lib-dash version to 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "aes": "^0.1.0",
-    "bitcore-lib-dash": "^0.13.18"
+    "bitcore-lib-dash": "^0.15.0"
   }
 }


### PR DESCRIPTION
- [x] `npm test`passes.